### PR TITLE
Fix "request" is None while creating analysisspec by JSONAPI (#2428)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 2.5.0 (unreleased)
 ------------------
 
+- #2427 Fix precision is not calculated from the rounded uncertainty
 - #2426 Fix ±0 is displayed for results within a range without uncertainty set
 - #2424 Fix sample in "registered" after creation when user cannot receive
 - #2422 Fix Maximum number of Iterations Exceeded when no catalogs set for AT type

--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -953,7 +953,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
           in accordance with the manual uncertainty set.
 
         - If Calculate Precision from Uncertainty is set in Analysis Service,
-          calculates the precision in accordance with the uncertainty infered
+          calculates the precision in accordance with the uncertainty inferred
           from uncertainties ranges.
 
         - If neither Manual Uncertainty nor Calculate Precision from
@@ -980,7 +980,23 @@ class AbstractAnalysis(AbstractBaseAnalysis):
                 strres = str(result)
                 numdecimals = strres[::-1].find('.')
                 return numdecimals
+
+            uncertainty = api.to_float(uncertainty)
+            # Get the 'raw' significant digits from uncertainty
+            sig_digits = get_significant_digits(uncertainty)
+            # Round the uncertainty to its significant digit.
+            # Needed because the precision for the result has to be based on
+            # the *rounded* uncertainty. Note the following for a given
+            # uncertainty value:
+            #   >>> round(0.09404, 2)
+            #   0.09
+            #   >>> round(0.09504, 2)
+            #   0.1
+            # The precision when the uncertainty is 0.09504 is not 2, but 1
+            uncertainty = abs(round(uncertainty, sig_digits))
+            # Return the significant digit to apply
             return get_significant_digits(uncertainty)
+
         return self.getField('Precision').get(self)
 
     @security.public

--- a/src/senaite/core/tests/doctests/Uncertainties.rst
+++ b/src/senaite/core/tests/doctests/Uncertainties.rst
@@ -246,6 +246,25 @@ Check the precision of the range 10-20 (0.4):
     >>> fe.getFormattedResult()
     '10.3'
 
+Check the precision is calculated based on the rounded uncertainty:
+
+    >>> uncertainties_2 = [
+    ...    {'intercept_min': '1.0', 'intercept_max': '100000', 'errorvalue': '9.9%'},
+    ...    {'intercept_min': '0.5', 'intercept_max': '0.9', 'errorvalue': '0'}
+    ... ]
+    >>> fe.setUncertainties(uncertainties_2)
+    >>> fe.setResult("9.6")
+    >>> fe.getResult()
+    '9.6'
+
+    >>> fe.getUncertainty()
+    '0.9504'
+
+    >>> fe.getPrecision()
+    0
+
+    >>> fe.getFormattedResult()
+    '10'
 
 Test uncertainty for results above/below detection limits
 .........................................................


### PR DESCRIPTION
* Calculate the precision from the rounded uncertainty

* Added doctest

* Make the doc-test more real-life

* Changelog

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/2428

## Current behavior before PR

in src/bika/lims/validators.py, line 818
        request = kwargs.get("REQUEST", {})
request is None, when create analysisspec by JSONAPI.
then, in src/bika/lims/validators.py, line 829
        service_uids = request.get("uids", [])
raise an error, 'NoneType' object has no attribute 'get'

## Desired behavior after PR is merged
fix the bug when "request" is None.
the analysisspec with "ResultsRange" by JSONAPI created work fine.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
