### PR TITLE
Update validators.py

### DIFF
--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -816,6 +816,8 @@ class AnalysisSpecificationsValidator:
     def __call__(self, value, *args, **kwargs):
         instance = kwargs["instance"]
         request = kwargs.get("REQUEST", {})
+        if request is None:
+            request = {}
         fieldname = kwargs["field"].getName()
 
         # This value in request prevents running once per subfield value.


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR
in src/bika/lims/validators.py, line 818
        request = kwargs.get("REQUEST", {})
request is None, when create analysisspec by JSONAPI.
then, in src/bika/lims/validators.py, line 829
        service_uids = request.get("uids", [])
raise an error, 'NoneType' object has no attribute 'get'

## Desired behavior after PR is merged
fix the bug when "request" is None.
the analysisspec with "ResultsRange" by JSONAPI created work fine.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
