### PR TITLE
Update resultsimport.py

### DIFF
--- a/src/senaite/core/exportimport/instruments/resultsimport.py
+++ b/src/senaite/core/exportimport/instruments/resultsimport.py
@@ -331,7 +331,7 @@ class InstrumentTXTResultsFileParser(InstrumentResultsFileParser):
         lines = [line.strip() for line in lines]
         return lines
 
-    def split_line(self, line):
+    def splitLine(self, line):
         sline = line.split(self._separator)
         return [token.strip() for token in sline]
 


### PR DESCRIPTION
keep the same class-method name in "class InstrumentTXTResultsFileParser(InstrumentResultsFileParser)", as in "class InstrumentCSVResultsFileParser(InstrumentResultsFileParser)"

## Description of the issue/feature this PR addresses
class InstrumentCSVResultsFileParser(InstrumentResultsFileParser):
         def splitLine(self, line)

class InstrumentTXTResultsFileParser(InstrumentResultsFileParser):
         def split_line(self, line)

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

## Desired behavior after PR is merged
keep the same class-method name for both
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
